### PR TITLE
Interrupts for the esp32c6 and uie.

### DIFF
--- a/include/hw/riscv/esp32c6_intmatrix.h
+++ b/include/hw/riscv/esp32c6_intmatrix.h
@@ -98,69 +98,83 @@ _Static_assert(sizeof(uint64_t) * 8 >= ESP32C6_INT_MATRIX_INPUTS,
                "A single 64-bit value must be able to represent a bitmap of all the interrupt sources");
 
 typedef enum {
-    ETS_WIFI_MAC_INTR_SOURCE = 0,               /**< interrupt of WiFi MAC, level*/
-    ETS_WIFI_MAC_NMI_SOURCE,                    /**< interrupt of WiFi MAC, NMI, use if MAC have bug to fix in NMI*/
-    ETS_WIFI_PWR_INTR_SOURCE,                   /**< */
-    ETS_WIFI_BB_INTR_SOURCE,                    /**< interrupt of WiFi BB, level, we can do some calibartion*/
-    ETS_BT_MAC_INTR_SOURCE,                     /**< will be cancelled*/
-    ETS_BT_BB_INTR_SOURCE,                      /**< interrupt of BT BB, level*/
-    ETS_BT_BB_NMI_SOURCE,                       /**< interrupt of BT BB, NMI, use if BB have bug to fix in NMI*/
-    ETS_RWBT_INTR_SOURCE,                       /**< interrupt of RWBT, level*/
-    ETS_RWBLE_INTR_SOURCE,                      /**< interrupt of RWBLE, level*/
-    ETS_RWBT_NMI_SOURCE,                        /**< interrupt of RWBT, NMI, use if RWBT have bug to fix in NMI*/
-    ETS_RWBLE_NMI_SOURCE,                       /**< interrupt of RWBLE, NMI, use if RWBT have bug to fix in NMI*/
-    ETS_I2C_MASTER_SOURCE,                      /**< interrupt of I2C Master, level*/
-    ETS_SLC0_INTR_SOURCE,                       /**< interrupt of SLC0, level*/
-    ETS_SLC1_INTR_SOURCE,                       /**< interrupt of SLC1, level*/
-    ETS_APB_CTRL_INTR_SOURCE,                   /**< interrupt of APB ctrl, ?*/
-    ETS_UHCI0_INTR_SOURCE,                      /**< interrupt of UHCI0, level*/
-    ETS_GPIO_INTR_SOURCE,                       /**< interrupt of GPIO, level*/
-    ETS_GPIO_NMI_SOURCE,                        /**< interrupt of GPIO, NMI*/
-    ETS_SPI1_INTR_SOURCE,                       /**< interrupt of SPI1, level, SPI1 is for flash read/write, do not use this*/
-    ETS_SPI2_INTR_SOURCE,                       /**< interrupt of SPI2, level*/
-    ETS_I2S1_INTR_SOURCE,                       /**< interrupt of I2S1, level*/
-    ETS_UART0_INTR_SOURCE,                      /**< interrupt of UART0, level*/
-    ETS_UART1_INTR_SOURCE,                      /**< interrupt of UART1, level*/
-    ETS_LEDC_INTR_SOURCE,                       /**< interrupt of LED PWM, level*/
-    ETS_EFUSE_INTR_SOURCE,                      /**< interrupt of efuse, level, not likely to use*/
-    ETS_TWAI_INTR_SOURCE,                       /**< interrupt of can, level*/
-    ETS_USB_SERIAL_JTAG_INTR_SOURCE,            /**< interrupt of USJ, level*/
-    ETS_RTC_CORE_INTR_SOURCE,                   /**< interrupt of rtc core, level, include rtc watchdog*/
-    ETS_RMT_INTR_SOURCE,                        /**< interrupt of remote controller, level*/
-    ETS_I2C_EXT0_INTR_SOURCE,                   /**< interrupt of I2C controller1, level*/
-    ETS_TIMER1_INTR_SOURCE,
-    ETS_TIMER2_INTR_SOURCE,
-    ETS_TG0_T0_LEVEL_INTR_SOURCE,               /**< interrupt of TIMER_GROUP0, TIMER0, level*/
-    ETS_TG0_WDT_LEVEL_INTR_SOURCE,              /**< interrupt of TIMER_GROUP0, WATCH DOG, level*/
-    ETS_TG1_T0_LEVEL_INTR_SOURCE,               /**< interrupt of TIMER_GROUP1, TIMER0, level*/
-    ETS_TG1_WDT_LEVEL_INTR_SOURCE,              /**< interrupt of TIMER_GROUP1, WATCHDOG, level*/
-    ETS_CACHE_IA_INTR_SOURCE,                   /**< interrupt of Cache Invalid Access, LEVEL*/
-    ETS_SYSTIMER_TARGET0_EDGE_INTR_SOURCE,      /**< interrupt of system timer 0, EDGE*/
-    ETS_SYSTIMER_TARGET1_EDGE_INTR_SOURCE,      /**< interrupt of system timer 1, EDGE*/
-    ETS_SYSTIMER_TARGET2_EDGE_INTR_SOURCE,      /**< interrupt of system timer 2, EDGE*/
-    ETS_SPI_MEM_REJECT_CACHE_INTR_SOURCE,       /**< interrupt of SPI0 Cache access and SPI1 access rejected, LEVEL*/
-    ETS_ICACHE_PRELOAD0_INTR_SOURCE,            /**< interrupt of ICache per load operation, LEVEL*/
-    ETS_ICACHE_SYNC0_INTR_SOURCE,               /**< interrupt of instruction cache sync done, LEVEL*/
-    ETS_APB_ADC_INTR_SOURCE,                    /**< interrupt of APB ADC, LEVEL*/
-    ETS_DMA_CH0_INTR_SOURCE,                    /**< interrupt of general DMA channel 0, LEVEL*/
-    ETS_DMA_CH1_INTR_SOURCE,                    /**< interrupt of general DMA channel 1, LEVEL*/
-    ETS_DMA_CH2_INTR_SOURCE,                    /**< interrupt of general DMA channel 2, LEVEL*/
-    ETS_RSA_INTR_SOURCE,                        /**< interrupt of RSA accelerator, level*/
-    ETS_AES_INTR_SOURCE,                        /**< interrupt of AES accelerator, level*/
-    ETS_SHA_INTR_SOURCE,                        /**< interrupt of SHA accelerator, level*/
-    ETS_FROM_CPU_INTR0_SOURCE,                  /**< interrupt0 generated from a CPU, level*/ /* Used for FreeRTOS */
-    ETS_FROM_CPU_INTR1_SOURCE,                  /**< interrupt1 generated from a CPU, level*/ /* Used for FreeRTOS */
-    ETS_FROM_CPU_INTR2_SOURCE,                  /**< interrupt2 generated from a CPU, level*/
-    ETS_FROM_CPU_INTR3_SOURCE,                  /**< interrupt3 generated from a CPU, level*/
-    ETS_ASSIST_DEBUG_INTR_SOURCE,               /**< interrupt of Assist debug module, LEVEL*/
-    ETS_DMA_APBPERI_PMS_INTR_SOURCE,
-    ETS_CORE0_IRAM0_PMS_INTR_SOURCE,
-    ETS_CORE0_DRAM0_PMS_INTR_SOURCE,
-    ETS_CORE0_PIF_PMS_INTR_SOURCE,
-    ETS_CORE0_PIF_PMS_SIZE_INTR_SOURCE,
-    ETS_BAK_PMS_VIOLATE_INTR_SOURCE,
-    ETS_CACHE_CORE0_ACS_INTR_SOURCE,
-    ETS_MAX_INTR_SOURCE,
+    ETS_RESERVED0_INTR_SOURCE = 0,
+    ETS_RESERVED1_INTR_SOURCE,
+    ETS_RESERVED2_INTR_SOURCE,
+    ETS_RESERVED3_INTR_SOURCE,
+    ETS_RESERVED4_INTR_SOURCE,
+    ETS_RESERVED5_INTR_SOURCE,
+    ETS_RESERVED6_INTR_SOURCE,
+    ETS_RESERVED7_INTR_SOURCE,
+    ETS_RESERVED8_INTR_SOURCE,
+    ETS_RESERVED9_INTR_SOURCE,
+    ETS_RESERVED10_INTR_SOURCE,
+    ETS_RESERVED11_INTR_SOURCE,
+    ETS_RESERVED12_INTR_SOURCE,
+    ETS_PMU_INTR_SOURCE,
+    ETS_EFUSE_INTR_SOURCE,
+    ETS_LP_RTC_TIMER_INTR_SOURCE,
+    ETS_LP_UART_INTR_SOURCE,
+    ETS_LP_I2C_INTR_SOURCE,
+    ETS_LP_WDT_INTR_SOURCE,
+    ETS_LP_PERI_TIMEOUT_INTR_SOURCE,
+    ETS_LP_APM_M0_INTR_SOURCE,
+    ETS_LP_APM_M1_INTR_SOURCE,
+    ETS_CPU_INTR_FROM_CPU_0_INTR_SOURCE,
+    ETS_CPU_INTR_FROM_CPU_1_INTR_SOURCE,
+    ETS_CPU_INTR_FROM_CPU_2_INTR_SOURCE,
+    ETS_CPU_INTR_FROM_CPU_3_INTR_SOURCE,
+    ETS_ASSIST_DEBUG_INTR_SOURCE,
+    ETS_TRACE_INTR_SOURCE,
+    ETS_CACHE_INTR_SOURCE,
+    ETS_CPU_PERI_TIMEOUT_INTR_SOURCE,
+    ETS_GPIO_INTERRUPT_PRO_INTR_SOURCE,
+    ETS_RESERVED31_INTR_SOURCE,
+    ETS_RESERVED32_INTR_SOURCE,
+    ETS_HP_PERI_TIMEOUT_INTR_SOURCE,
+    ETS_RESERVED34_INTR_SOURCE,
+    ETS_HP_APM_M0_INTR_SOURCE,
+    ETS_HP_APM_M1_INTR_SOURCE,
+    ETS_HP_APM_M2_INTR_SOURCE,
+    ETS_HP_APM_M3_INTR_SOURCE,
+    ETS_LP_APM0_INTR_SOURCE,
+    ETS_MSPI_INTR_SOURCE,
+    ETS_I2S_INTR_SOURCE,
+    ETS_UHCI0_INTR_SOURCE,
+    ETS_UART0_INTR_SOURCE,
+    ETS_UART1_INTR_SOURCE,
+    ETS_LEDC_INTR_SOURCE,
+    ETS_TWAI0_INTR_SOURCE,
+    ETS_TWAI1_INTR_SOURCE,
+    ETS_USB_SERIAL_JTAG_INTR_SOURCE,
+    ETS_RMT_INTR_SOURCE,
+    ETS_I2C_EXT0_INTR_SOURCE,
+    ETS_TG0_T0_INTR_SOURCE,
+    ETS_RESERVED52_INTR_SOURCE,
+    ETS_TG0_WDT_INTR_SOURCE,
+    ETS_TG1_T0_INTR_SOURCE,
+    ETS_RESERVED55_INTR_SOURCE,
+    ETS_TG1_WDT_INTR_SOURCE,
+    ETS_SYSTIMER_TARGET0_INTR_SOURCE,
+    ETS_SYSTIMER_TARGET1_INTR_SOURCE,
+    ETS_SYSTIMER_TARGET2_INTR_SOURCE,
+    ETS_APB_ADC_INTR_SOURCE,
+    ETS_PWM_INTR_SOURCE,
+    ETS_PCNT_INTR_SOURCE,
+    ETS_PARL_IO_INTR_SOURCE,
+    ETS_SLC0_INTR_SOURCE,
+    ETS_SLC1_INTR_SOURCE,
+    ETS_GDMA_IN_CH0_INTR_SOURCE,
+    ETS_GDMA_IN_CH1_INTR_SOURCE,
+    ETS_GDMA_IN_CH2_INTR_SOURCE,
+    ETS_GDMA_OUT_CH0_INTR_SOURCE,
+    ETS_GDMA_OUT_CH1_INTR_SOURCE,
+    ETS_GDMA_OUT_CH2_INTR_SOURCE,
+    ETS_GPSPI2_INTR_SOURCE,
+    ETS_AES_INTR_SOURCE,
+    ETS_SHA_INTR_SOURCE,
+    ETS_RSA_INTR_SOURCE,
+    ETS_ECC_INTR_SOURCE,
 } periph_interrupt_t;
 
 _Static_assert(ESP32C6_INT_MATRIX_INPUTS == ETS_MAX_INTR_SOURCE,

--- a/target/riscv/esp_cpu.h
+++ b/target/riscv/esp_cpu.h
@@ -66,6 +66,9 @@ typedef struct EspRISCVCPU {
     EspIntEnableCallback mie_enabled_callback;
     void* mie_enabled_opaque;
 
+    /* Should we add a 'uie_enabled_callback and uie_enabled_opaque as well?*/
+
+
     /*< public >*/
     /* The parent object already has a reset vector property */
     uint32_t hartid_base;


### PR DESCRIPTION
Listing the interrupt sources (from peripherals) for the esp32c6 and
individuating a possible place where to add uie support in addition to mie.